### PR TITLE
remove an empty repo

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -17,7 +17,6 @@
   <project path="abi/cpp" name="platform/abi/cpp" groups="pdk" />
   <project path="art" name="SlimRoms/android_art" remote="github" revision="lp5.1"  />
   <project path="bionic" name="SlimRoms/android_bionic" remote="github" revision="lp5.1" />
-  <project path="bootable/bootloader/legacy" name="platform/bootable/bootloader/legacy" />
   <project path="bootable/recovery" name="SlimRoms/bootable_recovery" remote="github" revision="lp5.1" />
   <project path="cts" name="platform/cts" groups="cts,pdk-cw-fs" />
   <project path="dalvik" name="platform/dalvik" groups="pdk-cw-fs" />


### PR DESCRIPTION
this repo was deleted a long time ago:
https://android.googlesource.com/platform/bootable/bootloader/legacy/+/3c491d6efb8ff2534a6934702760a6273f197918

Change-Id: I13444507a3e0db47b333019a782163fb25baedab
